### PR TITLE
Default family

### DIFF
--- a/fonts/manifest.yml
+++ b/fonts/manifest.yml
@@ -86,11 +86,13 @@ Source Code Pro:
 
 Source Sans Pro:
   - Italic
-  - Light
   - Bold Italic
-  - Light Italic
   - Regular
   - Bold
+
+Source Sans Pro Light:
+  - Regular
+  - Italic
 
 Source Serif Pro:
   - Bold

--- a/fonts/manifest.yml
+++ b/fonts/manifest.yml
@@ -34,6 +34,10 @@ Courier New:
 Cambria Math:
   - Regular
 
+EB Garamond 12:
+  - Regular
+  - Italic
+
 Work Sans:
   - Regular
   - Bold

--- a/xslt_src/m3aawg.report.core.xsl
+++ b/xslt_src/m3aawg.report.core.xsl
@@ -48,7 +48,7 @@
 	
 	<xsl:template match="/">
 		<xsl:call-template name="namespaceCheck"/>
-		<fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format" font-family="Garamond" font-size="12pt" xml:lang="{$lang}">
+		<fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format" font-family="EB Garamond 12" font-size="12pt" xml:lang="{$lang}">
 			<fo:layout-master-set>
 				
 				<!-- cover page -->


### PR DESCRIPTION
Though "Source Sans Pro" with the "Light" style works now, it could stop later, if we update Google formulas to a new format.

"Source Sans Pro Light" should work in both cases.

See fontist/fontist#247