### PR TITLE
#404 Notify private repos NIST, BSI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -131,6 +131,21 @@ jobs:
           name: pr-url-${{ matrix.flavor }}
           path: pr-url.txt
 
+  update-private-xslts:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [bsi, nist]
+    steps:
+      - uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}
+          repository: metanorma/mn-native-pdf-${{ matrix.flavor }}
+          event-type: metanorma/mn-native-pdf
+
   update-prs-list:
     runs-on: ubuntu-latest
     needs: update-xslts


### PR DESCRIPTION
### Problem

`mn-native-pdf` don't notify private flavors like `metanorma-nist` and `metanorna-bsi` directly. We have dedicated xslt repos per each private flavor `mn-native-pdf-nist`, `mn-native-pdf-bsi`.

But they all use common XSLTs and if they change private flavors miss those changes

### Solution

This PR "activates" relations:
 - mn-native-pdf -> mn-native-pdf-nist
 - mn-native-pdf -> mn-native-pdf-bsi

So once common XSLTs in `mn-native-pdf` pushed, CI on private xslt repos will be triggered also
