### PR TITLE
Bump GitHub actions/{cache,checkout} versions

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -30,7 +30,7 @@ jobs:
           ruby --version
           rbenv install 3.1.2
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: |
           git config --global --add safe.directory /__w/mn-native-pdf/mn-native-pdf
@@ -43,7 +43,7 @@ jobs:
           bundle config build.nokogiri --use-system-libraries
           bundle install --jobs 4 --retry 3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.fontist
           key: fontist-debian

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: make update-init update-modules
 
@@ -23,7 +23,7 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.fontist
           key: fontist-macos

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       common_changed: ${{ steps.common-changed.outputs.only_changed }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - id: common-changed
         uses: tj-actions/changed-files@v41.0.0
@@ -39,7 +39,7 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.fontist
           key: fontist-ubuntu
@@ -102,14 +102,14 @@ jobs:
           - flavor: bipm
             prefix: '{bipm,jcgm}'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@master
         with:
           name: xslt
           path: xslt
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           repository: metanorma/metanorma-${{ matrix.flavor }}
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: update-xslts
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4.1.7
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - run: choco install --no-progress grep gnuwin32-coreutils.install make curl unzip xsltproc
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: make update-init update-modules
         shell: pwsh
@@ -42,7 +42,7 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.fontist
           key: fontist-windows


### PR DESCRIPTION
### Motivation

`actions/cache@v2` will be deprecated in Jan 2025: https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes

This PR also updates `actions/checkout` from v2 (last commit was [March 2023](https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5)) to the most recent v4.

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
